### PR TITLE
Fix gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Don't wear out Chrome's refresh button.
 If you're on OSX 10.9+, simply:
 
 * `git clone https://github.com/ignu/trump-odds`
+* `cd trump-odds`
 * `bundle`
 * `rake`
 

--- a/trump_odds.gemspec
+++ b/trump_odds.gemspec
@@ -9,18 +9,14 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Len Smith"]
   spec.email         = ["len@barrison.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = "Get notified of any changes in fivethirtyeight from OSX"
+  spec.description   = %q{
+    Tired of refreshing fivethirtyeight.com to see the fate of our country?
+    Don't wear out Chrome's refresh button.
+    fivethirtyeight.com will be polled every minute, and you'll be alerted if there are any changes.
+  }
+  spec.homepage      = "https://github.com/ignu/trump-odds"
   spec.license       = "MIT"
-
-  # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
-  # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  end
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
Added a few changes I found when installing this amazing tool.
1. `bundle` would not work because there were `TODO`s in the descriptions. I was running bundler 1.12.5. The error was:

<img width="765" alt="screen shot 2016-10-04 at 11 18 06 am" src="https://cloud.githubusercontent.com/assets/35017/19080231/6ef996b0-8a24-11e6-8adc-f74acb816a24.png">
1. I skipped a step following the `README` directions (I basically just follow directions without thinking, much like Trump supporters).
